### PR TITLE
fix: The content is left without transparency, so the background part…

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -5,7 +5,7 @@ body {
 .body_up {
   position: relative;
   z-index: 99;
-  opacity: 0.95;
+  opacity: 1;
 }
 #particles-js {
   height: 100vh;


### PR DESCRIPTION
Authorization is requested to leave the content without transparency, so the background particles are not shown in the content.